### PR TITLE
update wuzz version to 0.2.0

### DIFF
--- a/Formula/wuzz.rb
+++ b/Formula/wuzz.rb
@@ -1,9 +1,9 @@
 class Wuzz < Formula
   desc "Interactive cli tool for HTTP inspection"
   homepage "https://github.com/asciimoo/wuzz"
-  url "https://github.com/asciimoo/wuzz/releases/download/v0.1.0/wuzz_darwin_amd64"
-  version "0.1.0"
-  sha256 "adcc33585265ef1df1b5b6f0e46b683c924add8f3207372f59dc6332bc1a6494"
+  url "https://github.com/asciimoo/wuzz/releases/download/v0.2.0/wuzz_darwin_amd64"
+  version "0.2.0"
+  sha256 "cd2afbca2a6415a618b960000176ba0d76882e93d2feb36588ecb68b3ee32fec"
 
   def install
     mv "wuzz_darwin_amd64", "wuzz"


### PR DESCRIPTION
I'm beginner of brew formula.
The value of sha156 is probably correct.
I could install v0.2.0 of wuzz without problem.
but, I want  you to check it.
thank you.